### PR TITLE
fix: enforce Python 3.8-3.13 version compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ venv312/*
 openwhisper_settings.json
 node_modules/*
 .cursor/worktrees.json
+.venv*/*

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ With CUDA enabled, faster-whisper runs 2-4x faster than CPU-only. The app auto-d
 
 ## Installation
 
-**Note:** It's recommended to set up a virtual environment (venv) to avoid package version conflicts. I have found Python 3.12 to be pretty stable with this codebase.
+**Note:** It's recommended to set up a virtual environment (venv) to avoid package version conflicts. I have found Python 3.12 to be pretty stable with this codebase. **Python 3.14+ is incompatible.**
 
 ```bash
 git clone https://github.com/Knuckles92/OpenWhisper
@@ -87,7 +87,7 @@ Access settings via **File > Settings** or the system tray menu. Available optio
 
 ## Requirements
 
-- Python 3.8+(3.12 recommended)
+- Python 3.8-3.13 (3.12 recommended)
 - Windows
 
 ## License

--- a/app_qt.py
+++ b/app_qt.py
@@ -1,6 +1,22 @@
 """
 Main application bootstrap
 """
+# Python version check - must run before any other imports
+import sys
+
+if sys.version_info < (3, 8) or sys.version_info >= (3, 14):
+    current_version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    print(f"""{"=" * 70}
+ERROR: Incompatible Python Version
+{"=" * 70}
+
+Current Python version: {current_version}
+Supported version range: Python 3.8 - 3.13
+
+OpenWhisper requires Python 3.8 or higher, but not Python 3.14+
+{"=" * 70}""")
+    sys.exit(1)
+
 import warnings
 
 warnings.filterwarnings("ignore", message="pkg_resources is deprecated")


### PR DESCRIPTION
Add runtime version check in app_qt.py that exits with clear error message if Python version is outside supported range. Update README.md to specify 3.8-3.13 compatibility and add .venv*/ to .gitignore for test environments.

Python 3.14 is currently unsupported because several core dependencies (e.g., faster-whisper, tokenizers, and av) do not yet provide prebuilt wheels for 3.14, causing pip to fall back to native compilation and fail on Windows.

Co-Authored-By: Claude Sonnet 4.5